### PR TITLE
Fix for clang 11 (OS X 10.15)

### DIFF
--- a/src/pytrec_eval.cpp
+++ b/src/pytrec_eval.cpp
@@ -813,7 +813,7 @@ PyMODINIT_FUNC PyInit_pytrec_eval_ext(void) {
         for (int i=0; i<te_num_trec_measures; i++) {
             if (te_trec_measures[i]->meas_params != NULL) {
                 te_trec_measures[measure_idx]->meas_params;
-                default_meas_params[i] = {
+                default_meas_params[i] = (PARAMS){
                     te_trec_measures[i]->meas_params->printable_params,
                     te_trec_measures[i]->meas_params->num_params,
                     te_trec_measures[i]->meas_params->param_values


### PR DESCRIPTION
The compiler (clang 11) was complaining 
```
src/pytrec_eval.cpp:816:42: error: expected expression
                default_meas_params[i] = {
```

This hint helps the compiler and removes the error.