### PR TITLE
enable github action testing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,41 @@
+# This workflow will install Python dependencies, and runs tests with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    strategy:
+      matrix:
+        python-version: [3.5, 3.8]
+        os: ['ubuntu-latest'] #, 'macOs-latest']
+        architecture: ['x64']
+
+    runs-on: ${{ matrix.os }}
+    steps:
+
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        
+    - name: Test with pytest
+      run: |
+        #install this software
+        python setup.py bdist
+        pip install --timeout=120 .
+        pip install pytest
+        pytest tests/*.py


### PR DESCRIPTION
This pull request enables continuous testing using Github Actions.

Once #23 is merged, you can enable macOs as well.