### PR TITLE
Windows support, Github Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.8]
-        os: ['ubuntu-latest', 'windows-latest'], #, 'macOs-latest']
+        os: ['ubuntu-latest', 'windows-latest'] #, 'macOs-latest']
         architecture: ['x64']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,4 +58,4 @@ jobs:
       shell: cmd
       run: |
         pip install pytest
-        pytest tests\*.py
+        pytest tests\pytrec_eval_tests.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,8 +14,8 @@ jobs:
     
     strategy:
       matrix:
-        python-version: [3.5] #[3.5, 3.8]
-        os: ['ubuntu-latest', 'windows-latest'] #, 'macOs-latest']
+        python-version: [3.5, 3.8]
+        os: ['ubuntu-latest', 'windows-latest', 'macOs-latest']
         architecture: ['x64']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,17 +41,11 @@ jobs:
         python setup.py bdist
         pip install --timeout=120 -vv .
 
-    - name: install-linux
-      if: matrix.os == 'ubuntu-latest'
+    - name: install-unix
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOs-latest'
       run: |
         python setup.py bdist
         pip install --timeout=120 .
-
-    - name: install-osx
-      if: matrix.os == 'macOs-latest'
-      run: |
-        python setup.py bdist
-        pip install --timeout=120 --user .
         
     - name: Test with pytest
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.8]
-        os: ['ubuntu-latest'] #, 'macOs-latest']
+        os: ['ubuntu-latest', 'windows-latest'], #, 'macOs-latest']
         architecture: ['x64']
 
     runs-on: ${{ matrix.os }}
@@ -26,16 +26,34 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+
+    - name: install-windows
+      if: matrix.os == 'windows-latest'
+      run: |
+        "%VS140COMNTOOLS%../../VC/vcvarsall.bat"
+        echo "$INCLUDE"
+        set INCLUDE "C:/Program Files (x86)/Windows Kits/10/Include/10.0.10240.0/ucrt"
+        python setup.py bdist
+        pip install --timeout=120 -vv .
+
+    - name: install-linux
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        python setup.py bdist
+        pip install --timeout=120 .
+
+    - name: install-osx
+      if: matrix.os == 'macOs-latest'
+      run: |
+        python setup.py bdist
+        pip install --timeout=120 --user .
         
     - name: Test with pytest
       run: |
-        #install this software
-        python setup.py bdist
-        pip install --timeout=120 .
         pip install pytest
         pytest tests/*.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,7 +47,15 @@ jobs:
         python setup.py bdist
         pip install --timeout=120 .
         
-    - name: Test with pytest
+    - name: Test-unix with pytest
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOs-latest'
       run: |
         pip install pytest
         pytest tests/*.py
+
+    - name: Test-windows with pytest
+      if: matrix.os == 'windows-latest'
+      shell: cmd
+      run: |
+        pip install pytest
+        pytest tests\*.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,41 @@
+# This workflow will install Python dependencies, and runs tests with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    strategy:
+      matrix:
+        python-version: [3.5, 3.8]
+        os: ['ubuntu-latest'] #, 'macOs-latest']
+        architecture: ['x64']
+
+    runs-on: ${{ matrix.os }}
+    steps:
+
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        
+    - name: Test with pytest
+      run: |
+        #install this software
+        python setup.py bdist
+        pip install --timeout=120 .
+        pip install pytest
+        pytest tests/*.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, and runs tests with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Continuous Integration
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ MANIFEST
 dist/
 build/
 *.pyc
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
         trec_eval_dir = os.path.join(tmp_dir, REMOTE_TREC_EVAL_ZIP_DIRNAME)
 
     for filename in os.listdir(trec_eval_dir):
-        if filename.endswith('.c'):
+        if filename.endswith('.c') and not filename == "trec_eval.c":
             TREC_EVAL_SRC.append(os.path.join(trec_eval_dir, filename))
 
     pytrec_eval_ext = Extension(

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
         'pytrec_eval_ext',
         sources=['src/pytrec_eval.cpp'] + TREC_EVAL_SRC,
         #windows doesnt need libm
-        libraries=['stdc++'] if sys.platform == 'win32' else ['m', 'stdc++'],
+        libraries=[''] if sys.platform == 'win32' else ['m', 'stdc++'],
         include_dirs=[trec_eval_dir],
         undef_macros=['NDEBUG'],
         extra_compile_args=['-g', '-Wall', '-O3'],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup, Extension
 import os
 import tempfile
 
-REMOTE_TREC_EVAL_ZIP = 'http://www.dcs.gla.ac.uk/~craigm/trec_eval.9.0.7.tar.gz'
+REMOTE_TREC_EVAL_ZIP = 'http://www.dcs.gla.ac.uk/~craigm/trec_eval.9.0.7.zip'
 
 REMOTE_TREC_EVAL_ZIP_DIRNAME = 'trec_eval.9.0.5'
 

--- a/setup.py
+++ b/setup.py
@@ -40,14 +40,14 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     if sys.platform == 'win32':
         for filename in os.listdir(os.path.join(trec_eval_dir, "windows")):
             if filename.endswith('.c') and not filename == "trec_eval.c":
-                TREC_EVAL_SRC.append(os.path.join(trec_eval_dir, filename))
+                TREC_EVAL_SRC.append(os.path.join(trec_eval_dir, "windows", filename))
 
     pytrec_eval_ext = Extension(
         'pytrec_eval_ext',
         sources=['src/pytrec_eval.cpp'] + TREC_EVAL_SRC,
         #windows doesnt need libm
         libraries=[] if sys.platform == 'win32' else ['m', 'stdc++'],
-        include_dirs=[trec_eval_dir],
+        include_dirs=[trec_eval_dir, os.path.join(trec_eval_dir, "windows")] if sys.platform == 'win32' else [trec_eval_dir],
         undef_macros=['NDEBUG'],
         extra_compile_args=['-g', '-Wall', '-O3'],
         define_macros=[('VERSIONID', '\"pytrec_eval\"'),

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
         'pytrec_eval_ext',
         sources=['src/pytrec_eval.cpp'] + TREC_EVAL_SRC,
         #windows doesnt need libm
-        libraries=[''] if sys.platform == 'win32' else ['m', 'stdc++'],
+        libraries=[] if sys.platform == 'win32' else ['m', 'stdc++'],
         include_dirs=[trec_eval_dir],
         undef_macros=['NDEBUG'],
         extra_compile_args=['-g', '-Wall', '-O3'],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import tempfile
 
 REMOTE_TREC_EVAL_ZIP = 'http://www.dcs.gla.ac.uk/~craigm/trec_eval.9.0.7.zip'
 
-REMOTE_TREC_EVAL_ZIP_DIRNAME = 'trec_eval.9.0.5'
+REMOTE_TREC_EVAL_ZIP_DIRNAME = 'trec_eval.9.0.7'
 
 LOCAL_TREC_EVAL_DIR = os.path.realpath(
     os.path.join(__file__, '..', 'trec_eval'))

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,9 @@ from distutils.core import setup, Extension
 import os
 import tempfile
 
-REMOTE_TREC_EVAL_ZIP = 'https://github.com/usnistgov/' \
-                       'trec_eval/archive/v9.0.5.zip'
+REMOTE_TREC_EVAL_ZIP = 'http://www.dcs.gla.ac.uk/~craigm/trec_eval.9.0.7.tar.gz'
 
-REMOTE_TREC_EVAL_ZIP_DIRNAME = 'trec_eval-9.0.5'
+REMOTE_TREC_EVAL_ZIP_DIRNAME = 'trec_eval.9.0.5'
 
 LOCAL_TREC_EVAL_DIR = os.path.realpath(
     os.path.join(__file__, '..', 'trec_eval'))

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ import os
 import sys
 import tempfile
 
-REMOTE_TREC_EVAL_ZIP = 'http://www.dcs.gla.ac.uk/~craigm/trec_eval.9.0.7.zip'
+REMOTE_TREC_EVAL_ZIP = 'https://github.com/usnistgov/trec_eval/archive/v9.0.8.tar.gz'
 
-REMOTE_TREC_EVAL_ZIP_DIRNAME = 'trec_eval.9.0.7'
+REMOTE_TREC_EVAL_ZIP_DIRNAME = 'trec_eval.9.0.8'
 
 LOCAL_TREC_EVAL_DIR = os.path.realpath(
     os.path.join(__file__, '..', 'trec_eval'))

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     for filename in os.listdir(trec_eval_dir):
         if filename.endswith('.c') and not filename == "trec_eval.c":
             TREC_EVAL_SRC.append(os.path.join(trec_eval_dir, filename))
+    #include the windows/ subdirectory on windows machines
+    if sys.platform == 'win32':
+        for filename in os.listdir(os.path.join(trec_eval_dir, "windows")):
+            if filename.endswith('.c') and not filename == "trec_eval.c":
+                TREC_EVAL_SRC.append(os.path.join(trec_eval_dir, filename))
 
     pytrec_eval_ext = Extension(
         'pytrec_eval_ext',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from distutils.core import setup, Extension
 import os
+import sys
 import tempfile
 
 REMOTE_TREC_EVAL_ZIP = 'http://www.dcs.gla.ac.uk/~craigm/trec_eval.9.0.7.zip'
@@ -39,7 +40,8 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     pytrec_eval_ext = Extension(
         'pytrec_eval_ext',
         sources=['src/pytrec_eval.cpp'] + TREC_EVAL_SRC,
-        libraries=['m', 'stdc++'],
+        #windows doesnt need libm
+        libraries=['stdc++'] if sys.platform == 'win32' else ['m', 'stdc++'],
         include_dirs=[trec_eval_dir],
         undef_macros=['NDEBUG'],
         extra_compile_args=['-g', '-Wall', '-O3'],

--- a/src/pytrec_eval.cpp
+++ b/src/pytrec_eval.cpp
@@ -557,7 +557,7 @@ static PyObject* RelevanceEvaluator_evaluate(RelevanceEvaluator* self, PyObject*
     all_results.results = queries;
 
     TREC_EVAL accum_eval;
-    accum_eval = (TREC_EVAL) {"all", 0, NULL, 0, 0};
+    accum_eval = TREC_EVAL {"all", 0, NULL, 0, 0};
 
     for (std::set<size_t>::iterator it = self->measures_->begin();
          it != self->measures_->end(); ++it) {

--- a/src/pytrec_eval.cpp
+++ b/src/pytrec_eval.cpp
@@ -21,16 +21,16 @@ extern "C" int te_form_res_rels_cleanup();
 #include <set>
 #include <string>
 
-extern int te_num_trec_measures;
-extern TREC_MEAS* te_trec_measures[];
-extern int te_num_trec_measure_nicknames;
-extern TREC_MEASURE_NICKNAMES te_trec_measure_nicknames[];
-extern int te_num_rel_info_format;
-extern REL_INFO_FILE_FORMAT te_rel_info_format[];
-extern int te_num_results_format;
-extern RESULTS_FILE_FORMAT te_results_format[];
-extern int te_num_form_inter_procs;
-extern RESULTS_FILE_FORMAT te_form_inter_procs[];
+extern "C" int te_num_trec_measures;
+extern "C" TREC_MEAS* te_trec_measures[];
+extern "C" int te_num_trec_measure_nicknames;
+extern "C" TREC_MEASURE_NICKNAMES te_trec_measure_nicknames[];
+extern "C" int te_num_rel_info_format;
+extern "C" REL_INFO_FILE_FORMAT te_rel_info_format[];
+extern "C" int te_num_results_format;
+extern "C" RESULTS_FILE_FORMAT te_results_format[];
+extern "C" int te_num_form_inter_procs;
+extern "C" RESULTS_FILE_FORMAT te_form_inter_procs[];
 
 #define CHECK(condition) assert(condition)
 #define CHECK_EQ(first, second) assert(first == second)

--- a/src/pytrec_eval.cpp
+++ b/src/pytrec_eval.cpp
@@ -557,8 +557,11 @@ static PyObject* RelevanceEvaluator_evaluate(RelevanceEvaluator* self, PyObject*
     all_results.results = queries;
 
     TREC_EVAL accum_eval;
+#ifdef _MSC_VER
     accum_eval = TREC_EVAL {"all", 0, NULL, 0, 0};
-
+#else
+    accum_eval = (TREC_EVAL) {"all", 0, NULL, 0, 0};
+#endif
     for (std::set<size_t>::iterator it = self->measures_->begin();
          it != self->measures_->end(); ++it) {
         const size_t measure_idx = *it;
@@ -813,7 +816,7 @@ PyMODINIT_FUNC PyInit_pytrec_eval_ext(void) {
         for (int i=0; i<te_num_trec_measures; i++) {
             if (te_trec_measures[i]->meas_params != NULL) {
                 te_trec_measures[measure_idx]->meas_params;
-                default_meas_params[i] = {
+                default_meas_params[i] = (PARAMS) {
                     te_trec_measures[i]->meas_params->printable_params,
                     te_trec_measures[i]->meas_params->num_params,
                     te_trec_measures[i]->meas_params->param_values

--- a/src/pytrec_eval.cpp
+++ b/src/pytrec_eval.cpp
@@ -816,7 +816,11 @@ PyMODINIT_FUNC PyInit_pytrec_eval_ext(void) {
         for (int i=0; i<te_num_trec_measures; i++) {
             if (te_trec_measures[i]->meas_params != NULL) {
                 te_trec_measures[measure_idx]->meas_params;
+#ifdef _MSC_VER                
+                default_meas_params[i] = PARAMS {
+#else 
                 default_meas_params[i] = (PARAMS) {
+#endif
                     te_trec_measures[i]->meas_params->printable_params,
                     te_trec_measures[i]->meas_params->num_params,
                     te_trec_measures[i]->meas_params->param_values

--- a/src/pytrec_eval.cpp
+++ b/src/pytrec_eval.cpp
@@ -33,6 +33,7 @@ extern "C" int te_num_form_inter_procs;
 extern "C" RESULTS_FILE_FORMAT te_form_inter_procs[];
 
 #define CHECK(condition) assert(condition)
+#define CHECK_STR_EQ(first, second) assert( std::string(first).compare(std::string(second)) == 0)
 #define CHECK_EQ(first, second) assert(first == second)
 #define CHECK_GT(first, second) assert(first > second)
 #define CHECK_GE(first, second) assert(first >= second)
@@ -773,7 +774,7 @@ PyMODINIT_FUNC PyInit_pytrec_eval_ext(void) {
     Py_INCREF(&RelevanceEvaluatorType);
     PyModule_AddObject(module, "RelevanceEvaluator", (PyObject*) &RelevanceEvaluatorType);
 
-    CHECK_EQ(te_trec_measure_nicknames[2].name, "all_trec");
+    CHECK_STR_EQ(te_trec_measure_nicknames[2].name, "all_trec");
 
     // Add set of all supported relevance measures.
     PyObject* const measures = PySet_New(NULL);


### PR DESCRIPTION
Dear all, please consider this PR for review. This patch:
1. uses a version of trec_eval that compiles under native Windows (using the Visual Studio build tools). I am sending those patches to NIST for inclusion in trec_eval. 
2. fixes Windows compilation for pytrec_eval
3. includes Github Actions continuous integration testing for Linux, Mac and Windows. You can see the output at https://github.com/cmacdonald/pytrec_eval/actions/runs/138328941
4. Includes the fixes for #23, which I have #ifdef'd around, as they didn't work for VS.

Perhaps once NIST have merged (1), we should be able to merge this, and plan to make a pypi Windows wheel.

It took a lot of attempts to get the Action workflow yml file correct, so perhaps squash merge would be appropriate.