### PR TITLE
Adding judged_only and allowing negative relevance_level

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -53,10 +53,11 @@ def compute_aggregated_measure(measure, values):
 
 
 class RelevanceEvaluator(_RelevanceEvaluator):
-    def __init__(self, query_relevance, measures, relevance_level=1):
+    def __init__(self, query_relevance, measures, relevance_level=1, judged_only=False):
         measures = self._expand_nicknames(measures)
         measures = self._combine_measures(measures)
-        super().__init__(query_relevance=query_relevance, measures=measures, relevance_level=relevance_level)
+        judged_only = 1 if judged_only else 0
+        super().__init__(query_relevance=query_relevance, measures=measures, relevance_level=relevance_level, judged_docs_only_flag=judged_only)
 
     def evaluate(self, scores):
         if not scores:

--- a/src/pytrec_eval.cpp
+++ b/src/pytrec_eval.cpp
@@ -318,14 +318,14 @@ static int RelevanceEvaluator_init(RelevanceEvaluator* self, PyObject* args, PyO
     PyObject* measures = NULL;
     PyObject* tmp_measures = NULL;
 
-    int32 relevance_level = 1;
+    int64 relevance_level = 1;
 
     static char* kwlist[] = {
         "query_relevance", "measures", "relevance_level",
         NULL};
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "OO|i", kwlist,
+            args, kwds, "OO|l", kwlist,
             &object_relevance_per_qid,
             &measures,
             &relevance_level)) {
@@ -347,13 +347,6 @@ static int RelevanceEvaluator_init(RelevanceEvaluator* self, PyObject* args, PyO
     if (!PySet_Check(measures)) {
         PyErr_SetString(PyExc_TypeError,
                         "Argument measures should be of type set.");
-
-        return -1;
-    }
-
-    if (relevance_level < 1) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Argument relevance_level should be positive.");
 
         return -1;
     }

--- a/src/pytrec_eval.cpp
+++ b/src/pytrec_eval.cpp
@@ -318,17 +318,19 @@ static int RelevanceEvaluator_init(RelevanceEvaluator* self, PyObject* args, PyO
     PyObject* measures = NULL;
     PyObject* tmp_measures = NULL;
 
-    int64 relevance_level = 1;
+    long relevance_level = 1;
+    long judged_docs_only_flag = 0;
 
     static char* kwlist[] = {
-        "query_relevance", "measures", "relevance_level",
+        "query_relevance", "measures", "relevance_level", "judged_docs_only_flag",
         NULL};
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "OO|l", kwlist,
+            args, kwds, "OO|ll", kwlist,
             &object_relevance_per_qid,
             &measures,
-            &relevance_level)) {
+            &relevance_level,
+            &judged_docs_only_flag)) {
         PyErr_SetString(
             PyExc_TypeError,
             "Expected object_relevance_per_qid dictionary "
@@ -351,10 +353,17 @@ static int RelevanceEvaluator_init(RelevanceEvaluator* self, PyObject* args, PyO
         return -1;
     }
 
+    if (judged_docs_only_flag != 0 && judged_docs_only_flag != 1) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Argument judged_docs_only_flag must be either 0 or 1.");
+
+        return -1;
+    }
+
     // Configure trec_eval session.
     self->epi_.query_flag = 0;
     self->epi_.average_complete_flag = 0;
-    self->epi_.judged_docs_only_flag = 0;
+    self->epi_.judged_docs_only_flag = judged_docs_only_flag;
     self->epi_.summary_flag = 0;
     self->epi_.relation_flag = 1;
     self->epi_.debug_level = 0;

--- a/tests/pytrec_eval_tests.py
+++ b/tests/pytrec_eval_tests.py
@@ -298,7 +298,7 @@ class PyTrecEvalUnitTest(unittest.TestCase):
         self.assertEqual(set(evaluator.evaluate(run)['q1'].keys()), {'ndcg_cut_1', 'ndcg_cut_4', 'ndcg_cut_15', 'ndcg_cut_20', 'recall_1000', 'P_200', 'P_15', 'P_10', 'P_5', 'P_30', 'P_100', 'P_20', 'P_500', 'P_1000'})
 
 
-    def test_relevance_level(self):
+    def test_relevance_level_and_judged(self):
         qrel = {
             'q1': {
                 'd1': 0,
@@ -330,6 +330,18 @@ class PyTrecEvalUnitTest(unittest.TestCase):
 
         evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=-1)
         self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 4/5)
+
+        evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=1, judged_only=True)
+        self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 3/5)
+
+        evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=2, judged_only=True)
+        self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 1/5)
+
+        evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=0, judged_only=True)
+        self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 4/5)
+
+        evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=-1, judged_only=True)
+        self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 4/5) # I'd expect 5/5, but https://github.com/usnistgov/trec_eval/issues/29
 
 
 # TODO(cvangysel): add tests to detect memory leaks.

--- a/tests/pytrec_eval_tests.py
+++ b/tests/pytrec_eval_tests.py
@@ -5,6 +5,8 @@ import unittest
 
 import pytrec_eval
 
+print(pytrec_eval)
+
 TREC_EVAL_TEST_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), '..', 'trec_eval', 'test')
 
@@ -294,6 +296,41 @@ class PyTrecEvalUnitTest(unittest.TestCase):
         # empty run
         evaluator = pytrec_eval.RelevanceEvaluator(qrel, ['ndcg_cut', 'ndcg_cut.1,4', 'ndcg_cut_20,4', 'ndcg_cut_15', 'recall.1000', 'P'])
         self.assertEqual(set(evaluator.evaluate(run)['q1'].keys()), {'ndcg_cut_1', 'ndcg_cut_4', 'ndcg_cut_15', 'ndcg_cut_20', 'recall_1000', 'P_200', 'P_15', 'P_10', 'P_5', 'P_30', 'P_100', 'P_20', 'P_500', 'P_1000'})
+
+
+    def test_relevance_level(self):
+        qrel = {
+            'q1': {
+                'd1': 0,
+                'd2': 1,
+                'd3': 2,
+                'd4': -1,
+                'd5': 1,
+            },
+        }
+        run = {
+            'q1': {
+                'd1': 5.,
+                'd2': 4.,
+                'd0': 3.,
+                'd3': 2.,
+                'd4': 1.,
+                'd5': 0.,
+            },
+        }
+
+        evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=1)
+        self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 2/5)
+
+        evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=2)
+        self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 1/5)
+
+        evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=0)
+        self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 3/5)
+
+        evaluator = pytrec_eval.RelevanceEvaluator(qrel, {'P.5'}, relevance_level=-1)
+        self.assertAlmostEqual(evaluator.evaluate(run)['q1']['P_5'], 4/5)
+
 
 # TODO(cvangysel): add tests to detect memory leaks.
 class PyTrecEvalIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
The `-J` flag in trec_eval allows discards unjudged documents when computing relevance scores. While it's normally not advised to use this, it is sometimes handy. Tests included.

Also, there used to be an error that was thrown when relevance_level was less than 1. There's nothing in trec_eval that imposes this limitation, so I removed the check and added tests to make sure it works correctly. (Needed to change the data type to long to match that of epi.) Again, usually not an issue, but sometimes handy.